### PR TITLE
Changed option for setting the max number of task steps from -s to -z.

### DIFF
--- a/src/tmsmt
+++ b/src/tmsmt
@@ -67,7 +67,7 @@ Options:
   -g <scene-file>             Goal scene file
   -o <output-plan-file>       Output plan file
   -q <plan-file>              Initial configuration
-  -s <max-steps>              Maximum number of task steps
+  -z, --steps <max-steps>     Maximum number of task steps
   -m <motion-timeout>         Initial motion planning timeout
   -r <resolution>             Discretization resolution
   -T <times-file>             Append timing data to times-file
@@ -145,7 +145,7 @@ EOF
             shift;
             export TMSMT_RESOLUTION="$1"
             ;;
-        -s|--steps)
+        -z|--steps)
             shift;
             export TMSMT_MAX_STEPS="$1"
             ;;


### PR DESCRIPTION
The script to call tmkit has two conflicting options that use -s. One is for setting the scene file, one is for setting the max number of task steps While there is an alternative form for the steps options, --steps, it is not mentioned in the --help output. I've changed the single character option for steps to -z and added mention of the alternative --steps in the --help output. This PR resolves #16 